### PR TITLE
Allow unfollow wrong username

### DIFF
--- a/helpers/operations/unfollow.js
+++ b/helpers/operations/unfollow.js
@@ -21,10 +21,6 @@ const parse = (query) => {
 };
 
 const validate = async (query, errors) => {
-  if (!isEmpty(query.following) && !await userExists(query.following)) {
-    errors.push(`the user ${query.following} doesn't exist`);
-  }
-
   if (!isEmpty(query.follower) && !await userExists(query.follower)) {
     errors.push(`the user ${query.follower} doesn't exist`);
   }


### PR DESCRIPTION
There was an issue on Busy new-design where users been able to add `profile.name` instead of username on their list of following. Some users were not able to load their list of following, i'm doing this PR to try to "unfollow" wrong username.