### PR TITLE
Update steem to v0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "sc2-sdk": "0.0.1",
     "sequelize": "^3.30.4",
     "serve-favicon": "^2.4.5",
-    "steem": "^0.6.1",
+    "steem": "^0.6.4",
     "store": "^1.3.20",
     "style-loader": "^0.13.1",
     "tether": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,8 +1298,8 @@ buffer@^4.9.0:
     isarray "^1.0.0"
 
 buffer@^5.0.6:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.7.tgz#570a290b625cf2603290c1149223d27ccf04db97"
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.8.tgz#84daa52e7cf2fa8ce4195bc5cf0f7809e0930b24"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -6686,7 +6686,7 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
-steem@^0.6.1:
+steem@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/steem/-/steem-0.6.4.tgz#b34915cb90e729be9171721db81c5c1623e8d109"
   dependencies:
@@ -7395,13 +7395,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@1, which@^1.2.9:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
-  dependencies:
-    isexe "^2.0.0"
-
-which@1.2.x:
+which@1, which@1.2.x, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:


### PR DESCRIPTION
On the previous version of Steem.js some operations mapping had wrong role and hot signing was not working for these operations.