### PR TITLE
eslint improvement

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5,8 +5,7 @@ import Header from './widgets/Header';
 
 export default class App extends PureComponent {
   static propTypes = {
-    // eslint-disable-next-line react/forbid-prop-types
-    children: PropTypes.object,
+    children: PropTypes.shape(),
     auth: PropTypes.shape({
       user: PropTypes.shape({
         name: PropTypes.string,

--- a/src/components/Accounts/Authorize.js
+++ b/src/components/Accounts/Authorize.js
@@ -12,8 +12,7 @@ export default class Authorize extends Component {
       username: PropTypes.string,
       role: PropTypes.string,
     }),
-    // eslint-disable-next-line react/forbid-prop-types
-    location: PropTypes.object,
+    location: PropTypes.shape(),
   }
 
   constructor(props) {

--- a/src/components/Apps/AppPreview.js
+++ b/src/components/Apps/AppPreview.js
@@ -13,8 +13,7 @@ const AppPreview = ({ app }) => (
 );
 
 AppPreview.propTypes = {
-  // eslint-disable-next-line react/forbid-prop-types
-  app: PropTypes.object,
+  app: PropTypes.shape(),
 };
 
 export default AppPreview;

--- a/src/components/Apps/AuthorizedApps.js
+++ b/src/components/Apps/AuthorizedApps.js
@@ -5,8 +5,7 @@ import Loading from '../../widgets/Loading';
 
 export default class AuthorizedApps extends Component {
   static propTypes = {
-    // eslint-disable-next-line react/forbid-prop-types
-    auth: PropTypes.object,
+    auth: PropTypes.shape(),
   }
 
   constructor(props) {

--- a/src/components/Apps/CreateApp.js
+++ b/src/components/Apps/CreateApp.js
@@ -13,8 +13,7 @@ import { sleep } from '../../../helpers/utils';
 
 class CreateApp extends React.Component {
   static propTypes = {
-    // eslint-disable-next-line react/forbid-prop-types
-    auth: PropTypes.object,
+    auth: PropTypes.shape(),
   }
 
   state = {

--- a/src/components/Auth/RequireLogin.js
+++ b/src/components/Auth/RequireLogin.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/forbid-prop-types */
 import React, { PropTypes } from 'react';
 import { browserHistory } from 'react-router';
 import Loading from '../../widgets/Loading';
@@ -19,9 +18,9 @@ const RequireLogin = ({ auth, location, children }) => {
 };
 
 RequireLogin.propTypes = {
-  location: PropTypes.object,
-  auth: PropTypes.object,
-  children: PropTypes.object,
+  location: PropTypes.shape(),
+  auth: PropTypes.shape(),
+  children: PropTypes.shape(),
 };
 
 export default RequireLogin;

--- a/src/components/Docs/Steemjs.js
+++ b/src/components/Docs/Steemjs.js
@@ -32,8 +32,7 @@ const Method = ({ method }) => {
 };
 
 Method.propTypes = {
-  // eslint-disable-next-line react/forbid-prop-types
-  method: PropTypes.object,
+  method: PropTypes.shape(),
 };
 
 const Operation = ({ operation }) => {
@@ -65,8 +64,7 @@ const Operation = ({ operation }) => {
 };
 
 Operation.propTypes = {
-  // eslint-disable-next-line react/forbid-prop-types
-  operation: PropTypes.object,
+  operation: PropTypes.shape(),
 };
 
 const Steemjs = () =>

--- a/src/components/Sign.js
+++ b/src/components/Sign.js
@@ -15,10 +15,8 @@ import './Sign.less';
 
 export default class Sign extends Component {
   static propTypes = {
-    // eslint-disable-next-line react/forbid-prop-types
-    location: PropTypes.object,
-    // eslint-disable-next-line react/forbid-prop-types
-    params: PropTypes.object,
+    location: PropTypes.shape(),
+    params: PropTypes.shape(),
   }
 
   constructor(props) {

--- a/src/components/Sign/Error.js
+++ b/src/components/Sign/Error.js
@@ -12,8 +12,7 @@ const SignError = ({ error, resetForm }) =>
 
 SignError.propTypes = {
   resetForm: PropTypes.func,
-  // eslint-disable-next-line react/forbid-prop-types
-  error: PropTypes.object,
+  error: PropTypes.shape(),
 };
 
 export default SignError;

--- a/src/components/Sign/Placeholder/Comment.js
+++ b/src/components/Sign/Placeholder/Comment.js
@@ -48,8 +48,7 @@ const SignPlaceholderComment = ({
 
 SignPlaceholderComment.propTypes = {
   type: PropTypes.string,
-  // eslint-disable-next-line react/forbid-prop-types
-  query: PropTypes.object,
+  query: PropTypes.shape(),
 };
 
 export default SignPlaceholderComment;

--- a/src/components/Sign/Placeholder/Default.js
+++ b/src/components/Sign/Placeholder/Default.js
@@ -28,8 +28,7 @@ const SignPlaceholderDefault = ({
 
 SignPlaceholderDefault.propTypes = {
   type: PropTypes.string,
-  // eslint-disable-next-line react/forbid-prop-types
-  query: PropTypes.object,
+  query: PropTypes.shape(),
   params: PropTypes.arrayOf(PropTypes.string),
 };
 

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -19,10 +19,8 @@ import './styles/common.less';
 )
 export default class Wrapper extends Component {
   static propTypes = {
-    // eslint-disable-next-line react/forbid-prop-types
-    children: PropTypes.object,
-    // eslint-disable-next-line react/forbid-prop-types
-    auth: PropTypes.object,
+    children: PropTypes.shape(),
+    auth: PropTypes.shape(),
     authenticate: PropTypes.func,
     setLocale: PropTypes.func,
     locale: PropTypes.string,


### PR DESCRIPTION
Remove the eslint directive '// eslint-disable-next-line react/forbid-prop-types' as it can be replaced by the shape() propTypes without throwing an error